### PR TITLE
Run daemons as root user to simplify volume and docker.sock mounting...

### DIFF
--- a/Dockerfile.gocd-agent
+++ b/Dockerfile.gocd-agent
@@ -3,7 +3,15 @@ FROM phusion/baseimage:0.9.16
 MAINTAINER Aravind SV <arvind.sv@gmail.com>
 
 RUN rm -rf /etc/service/sshd /etc/my_init.d/00_regen_ssh_host_keys.sh
-RUN apt-get update && apt-get install -y -q unzip openjdk-7-jre-headless git
+RUN apt-get update && apt-get install -y -q unzip openjdk-7-jre-headless git vim
+
+# Download the docker binary
+ENV DOCKER_VERSION=1.6.2
+RUN wget https://get.docker.com/builds/Linux/x86_64/docker-${DOCKER_VERSION} && \
+    chmod +x docker-${DOCKER_VERSION} && \
+    mv docker-${DOCKER_VERSION} /usr/local/bin/docker
+
+RUN echo "StrictHostKeyChecking no" >> /etc/ssh/ssh_config
 
 RUN mkdir /etc/service/go-agent
 ADD gocd-agent/go-agent-start.sh /etc/service/go-agent/run

--- a/Dockerfile.gocd-agent
+++ b/Dockerfile.gocd-agent
@@ -16,4 +16,4 @@ RUN sed -i 's/DAEMON=Y/DAEMON=N/' /etc/default/go-agent
 
 RUN apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
-CMD ["/sbin/my_init"]
+CMD ["/usr/share/go-agent/agent.sh"]

--- a/Dockerfile.gocd-server
+++ b/Dockerfile.gocd-server
@@ -11,11 +11,8 @@ ADD gocd-server/go-server-start.sh /etc/service/go-server/run
 
 ADD http://download.go.cd/gocd-deb/go-server-15.1.0-1863.deb /tmp/go-server.deb
 
-RUN ["groupadd", "-r", "go"]
-RUN ["useradd", "-r", "-c", "Go User", "-g", "go", "-d", "/var/go", "-m", "-s", "/bin/bash", "go"]
 RUN ["mkdir", "-p", "/var/lib/go-server/addons", "/var/log/go-server", "/etc/go", "/go-addons"]
 RUN ["touch", "/etc/go/postgresqldb.properties"]
-RUN ["chown", "-R", "go:go", "/var/lib/go-server", "/var/log/go-server", "/etc/go", "/go-addons"]
 VOLUME ["/var/lib/go-server", "/var/log/go-server", "/etc/go", "/go-addons"]
 
 WORKDIR /tmp
@@ -25,4 +22,4 @@ EXPOSE 8153 8154
 
 RUN apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
-CMD ["/sbin/my_init"]
+CMD ["/usr/share/go-server/server.sh"]

--- a/gocd-agent/go-agent-start.sh
+++ b/gocd-agent/go-agent-start.sh
@@ -16,4 +16,4 @@ echo "agent.auto.register.key=$AGENT_KEY" >/var/lib/go-agent/config/autoregister
 if [ -n "$AGENT_RESOURCES" ]; then echo "agent.auto.register.resources=$AGENT_RESOURCES" >>/var/lib/go-agent/config/autoregister.properties; fi
 if [ -n "$AGENT_ENVIRONMENTS" ]; then echo "agent.auto.register.environments=$AGENT_ENVIRONMENTS" >>/var/lib/go-agent/config/autoregister.properties; fi
 
-/sbin/setuser go /etc/init.d/go-agent start
+/etc/init.d/go-agent start

--- a/gocd-server/go-server-start.sh
+++ b/gocd-server/go-server-start.sh
@@ -7,8 +7,7 @@
 show_msg "Starting Go Server ..."
 
 /bin/cp -va /go-addons/. /var/lib/go-server/addons/
-chown -R go:go /var/lib/go-server/addons/
-/sbin/setuser go /etc/init.d/go-server start &
+/etc/init.d/go-server start &
 
 wait_for_go_server
 


### PR DESCRIPTION
…on CoreOS.

Download the docker binary.

Disable strict host key checking in SSH to allow non-interactive SSH conections to Github
